### PR TITLE
Fixed react-router and history crazy peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,12 +52,12 @@
     "browsernizr": "^2.0.1",
     "express": "^4.13.3",
     "extract-text-webpack-plugin": "^0.9.1",
-    "history": "1.13.1",
+    "history": "1.17.0",
     "node-jsx": "^0.13.3",
     "piping": "^0.3.0",
     "react": "^0.14.0",
     "react-bootstrap": "^0.27.3",
     "react-dom": "^0.14.0",
-    "react-router": "^1.0.0"
+    "react-router": "1.0.3"
   }
 }


### PR DESCRIPTION
Using caret versioning for react-router causing it to install 1.x.x, which in my test will install 1.0.3 and need history 1.17.0, this causing broken initial npm install. The proposed fix would be use fixed dependency for both react-router and history. If you worry about future patch/bugfix, you can easily run `npm outdated` command to show which version is available for update.
